### PR TITLE
Fix REQUIRE macro not being usable with templated types.

### DIFF
--- a/catch.hpp
+++ b/catch.hpp
@@ -52,7 +52,7 @@
 
 #define TEST_CASE(TestName) CATCH_MINI_TESTCASE(TestName, __FILE__, __LINE__)
 
-#define REQUIRE(Expr) CATCH_MINI_TEST(Expr, __FILE__, __LINE__)
+#define REQUIRE(...) CATCH_MINI_TEST((__VA_ARGS__), __FILE__, __LINE__)
 
 
 // INTERNAL API //


### PR DESCRIPTION
At the moment, trying to use REQUIRE like
```cpp
#define CATCH_CONFIG_MAIN
#include "catch.hpp"

template <typename T, typename U>
struct Foo
{
    static constexpr T first{0};
    static constexpr U second{0};
};

TEST_CASE("Just testing")
{
    REQUIRE(Foo<int, int>::first == 0);
    REQUIRE(Foo<int, int>::second == 0);
}
```

results in

```
error: macro "REQUIRE" passed 2 arguments, but takes just 1
     REQUIRE(Foo<int, int>::first == 0);
```
because the preprocessor reads everything after the comma as a second argument. 

The use of a variadic macro instead of a macro with single argument for REQUIRE resolves this.
