### PR TITLE
Fix: Double bracketing in reported assertion.

### DIFF
--- a/catch.hpp
+++ b/catch.hpp
@@ -175,7 +175,7 @@ namespace
                     ++numFailedTestCases;
 
                     std::cout << assertion.file << ':' << assertion.line << ": FAILED:" << std::endl;
-                    std::cout << "\tREQUIRE(" << assertion.expr << ")" << std::endl;
+                    std::cout << "\tREQUIRE" << assertion.expr << std::endl;
                     std::cout << std::endl;
                 }
                 catch(const std::exception& exception)


### PR DESCRIPTION
As a side-effect #1, when an assertion fails, it is reported like
```
tests/main_test.cpp:28: FAILED:
	REQUIRE((1 == 0))
```
with two sets of brackets. This is because `__VA_ARGS__` is passed to `CATCH_MINI_TEST` with brackets, and the brackets are included in the macro expansion. 

This misreporting can be confusing, as the user's expectation is that it reports the exact line of code they've written for that assertion.

The fix is easy - simply don't print our own set of brackets.